### PR TITLE
adds permissions to accept to ship example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ jobs:
         contains(github.event.workflow_run.pull_requests.*.base.ref, 'main')
       }}
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ jobs:
         contains(github.event.workflow_run.pull_requests.*.base.ref, 'main')
       }}
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - uses: actions/checkout@v3
 
@@ -60,7 +61,7 @@ jobs:
           merge-method: merge # optional
           timeout: 0 # optional
           checks-watch-interval: 10 # optional
-          fail-if-timeout: false # optinal
+          fail-if-timeout: false # optional
           request-zero-accept-zero: false # optional
           custom-hashtag: '#accept2ship' #optional
 


### PR DESCRIPTION
Hello from another Ex-FB :) 

Quick and easy change to add a permission write-all to the readme example. This was needed to fix some issues when I integrated it into our private repo. 

```
HttpError: Resource not accessible by integration
    at file:///home/runner/work/_actions/CatChen/accept-to-ship-action/v0.3/webpack:/accept-to-ship-action/node_modules/@octokit/request/dist-node/index.js:86:1
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Job.doExecute (file:///home/runner/work/_actions/CatChen/accept-to-ship-action/v0.3/webpack:/accept-to-ship-action/node_modules/bottleneck/light.js:405:1)
```


```
  Error: Failed to check if pull request is merged: 403
      at file:///home/runner/work/_actions/CatChen/accept-to-ship-action/v0.3/webpack:/accept-to-ship-action/src/mergePullRequest.ts:36:1
      at Generator.throw (<anonymous>)
      at rejected (file:///home/runner/work/_actions/CatChen/accept-to-ship-action/v0.3/webpack:/accept-to-ship-action/src/mergePullRequest.ts:6:1)
```
